### PR TITLE
IMP access control on write

### DIFF
--- a/orm_mongodb.py
+++ b/orm_mongodb.py
@@ -284,6 +284,8 @@ class orm_mongodb(orm.orm_template):
         if not ids:
             return True
 
+        self.pool.get('ir.model.access').check(cr, user, self._name,
+                                               'write', context=context)
         #Pre process date and datetime fields
         self.preformat_write_fields(vals)
         self.write_binary_gridfs_fields(vals)


### PR DESCRIPTION
This allows write control of mongo models by ir.model.access.