### PR TITLE
FIX Convert port setup to int

### DIFF
--- a/mongodb2.py
+++ b/mongodb2.py
@@ -109,7 +109,7 @@ class MDBConn(object):
 
         try:
             self.connection = Connection(tools.config['mongodb_host'],
-                                        tools.config['mongodb_port'])
+                                         int(tools.config['mongodb_port']))
         except Exception, e:
             raise except_orm('MongoDB connection error', e)
 


### PR DESCRIPTION
ERP start fails on mongodb port setup if is set. The param has to be convert to an integer