### PR TITLE
FIX Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymongo==3.0.3
+pymongo==2.9


### PR DESCRIPTION
Pymongo 2.9 does not break aggregation framework results. Beginning 3.0 aggregation results are a cursor, no longer a document. 